### PR TITLE
Fixed Rbx Version Printf bug

### DIFF
--- a/VersionScanner/src/main.cpp
+++ b/VersionScanner/src/main.cpp
@@ -69,7 +69,7 @@ int main()
     curl_easy_cleanup(session);
     curl_global_cleanup();
 
-    std::printf("Current Roblox Version: %s\n", response);
+    std::cout << "Current Roblox Version: " << response << "\n";
 
     if (!std::filesystem::exists(versions_path))
     {


### PR DESCRIPTION
Fixed the bug where the Latest Roblox Version would be displayed as emojis when pushed to stdout by printf. Switching to cout fixed the issue.

![alt text](https://i.imgur.com/4fB5zyb.png)